### PR TITLE
fix(copy code): corrects the copy code button

### DIFF
--- a/docs/site/main.js
+++ b/docs/site/main.js
@@ -633,7 +633,7 @@ cse111.linenums = {
 	addCodeCopyButtons : function() {
 		function copyFunc(event) {
 			let button = event.currentTarget;
-			let pre = button.parentElement;
+			let pre = button.parentElement.querySelector('pre.hljs');
 			let text = pre.textContent;
 
 			// Copy the text to the clipboard.
@@ -669,8 +669,7 @@ cse111.linenums = {
 					{type : 'button', title : copyHint});
 			button.appendChild(image);
 			button.addEventListener('click', copyFunc);
-			let pre = div.querySelector('pre.python, pre.csv, pre.sql');
-			pre.appendChild(button);
+			div.appendChild(button);
 		}
 	}
 };

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -717,7 +717,7 @@ article pre.console > span.fail { color: red; }
 
 @media screen {
 	/* A button that copies code to the clipboard. */
-	article div.example > pre > .copy {
+	article div.example > button.copy {
 		visibility: hidden;
 		position: absolute;
 		top: 0.5em;
@@ -731,12 +731,12 @@ article pre.console > span.fail { color: red; }
 		cursor: pointer;
 	}
 
-	article div.example > pre:hover > .copy {
+	article div.example:hover > button.copy {
 		visibility: visible;
 	}
 }
 @media print {
-	article div.example > pre > .copy {
+	article div.example > button.copy {
 		display: none;
 	}
 }


### PR DESCRIPTION
This fix places the copy code button outside the `pre` tags for code samples. Now when users press the copy button it does not append the help text (title text) at the end of their code.